### PR TITLE
Fix camera intrinsics for crop, no resize case

### DIFF
--- a/dataset/co3d_dataset.py
+++ b/dataset/co3d_dataset.py
@@ -514,7 +514,13 @@ class Co3dDataset(torch.utils.data.Dataset):
 
         # now, convert from pixels to Pytorch3D v0.5+ NDC convention
         if self.image_height is None or self.image_width is None:
-            out_size = list(reversed(entry.image.size))
+            if self.box_crop:
+                out_size = [
+                    clamp_bbox_xyxy[2] - clamp_bbox_xyxy[0],
+                    clamp_bbox_xyxy[3] - clamp_bbox_xyxy[1],
+                ]
+            else:
+                out_size = list(reversed(entry.image.size))            
         else:
             out_size = [self.image_width, self.image_height]
 


### PR DESCRIPTION
I believe that there is a bug in the Co3dDataset class, in the `_get_pytorch3d_camera`, in the case where the dataset is loaded with `self.box_crop=True` and without resizing (i.e. `self.image_height is None or self.image_width is None`). The bug comes from the `out_size` parameter not being set appropriately under these conditions.

The code under the condition at https://github.com/facebookresearch/co3d/blob/7ee9f5ba0b87b22e1dfe92c4d2010cb14dd467a6/dataset/co3d_dataset.py#L516 returns `out_size` as the original image size, in cases where `self.image_height is None or self.image_width is None`. However, if `self.box_crop=True`, the `out_size` should be the size of the crop, not the whole image.

Plotting the back-projected point clouds under various resize/crop settings demonstrates the error - below, the purple point cloud is from a dataset loaded without cropping (either `self.image_height=None` or with some value e.g. `self.image_height=256` -- both, correctly, lead to the same back-projection, though with different numbers of points). The blue point cloud is from a cropped and resized dataset (`self.box_crop=True`, `self.image_height=256`, `self.image_width=256`). This back-projects to overlap appropriately with the full point cloud. The red point cloud is from the problematic combination (`self.box_crop=True`, `self.image_height=None`, `self.image_width=None`), and can be seen to _not_ overlap with either of the other point clouds.
<img width="486" alt="Screenshot 2022-04-14 at 13 54 57" src="https://user-images.githubusercontent.com/28831431/163396630-62e94df0-993e-40f2-90e5-a3a75317dd70.png">
<img width="538" alt="Screenshot 2022-04-14 at 13 55 06" src="https://user-images.githubusercontent.com/28831431/163396656-97f675e6-a616-4a1f-a999-46d196156de7.png">

By contrast, the following show two views with the bugfix (green point cloud comes from dataset with same crop-and-no-resize conditions as the red point cloud before). It can be seen that the green point cloud is now fully aligned with the other back-projected point clouds.
<img width="471" alt="Screenshot 2022-04-14 at 13 55 46" src="https://user-images.githubusercontent.com/28831431/163396675-80beddec-f735-494d-bb1e-adf678d339dc.png">
<img width="483" alt="Screenshot 2022-04-14 at 13 56 04" src="https://user-images.githubusercontent.com/28831431/163396711-118a930e-c81e-48c9-8c0d-7d36e3ffb5ac.png">

I believe that the no-crop-or-resize format is being quite commonly used by users of the dataset, so I hope that this pull request will prove useful.

Thanks for reviewing.