### PR TITLE
Fixed dataset error when not loading masks

### DIFF
--- a/dataset/co3d_dataset.py
+++ b/dataset/co3d_dataset.py
@@ -411,6 +411,9 @@ class Co3dDataset(torch.utils.data.Dataset):
         return frame_data
 
     def _load_crop_fg_probability(self, entry):
+        fg_probability = None
+        full_path = None
+        bbox_xywh = None
         clamp_bbox_xyxy = None
         if (self.load_masks or self.box_crop) and entry.mask is not None:
             full_path = os.path.join(self.dataset_root, entry.mask.path)


### PR DESCRIPTION
When masks are not loaded by the Co3dDataset, `fg_probability`, `full_path`, and `bbox_xywh` are not set, resulting in a NameError. Fixed this by setting a default value.